### PR TITLE
chore: add docs on how to use the `registryCredentialsSecret` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ spec:
   hostLabels:
     some-label: value
   # Which wasmCloud version to use
-  version: 0.81.0
+  version: 0.82.0
   # The name of a secret in the same namespace that provides the required secrets.
   secretName: cluster-secrets
   # Enable the following to run the wasmCloud hosts as a DaemonSet
   #daemonset: true
+  # The name of the image pull secret to use with wasmCloud hosts so that they
+  # can authenticate to a private registry to pull components.
+  # registryCredentialsSecret: my-registry-secret
 ```
 
 The CRD requires a Kubernetes Secret with the following keys:
@@ -48,12 +51,22 @@ data:
   WASMCLOUD_CLUSTER_SEED: <seed>
   # Only required if using a NATS creds file
   # nats.creds: <base64 encoded creds file>
-  # Only required if using OCI private registry
-  # OCI_REGISTRY_PASSWORD: <password>
 ```
 
 The operator will fail to provision the wasmCloud Deployment if any of these
 secrets are missing!
+
+### Image Pull Secrets
+
+You can also specify an image pull secret to use use with the wasmCloud hosts
+so that they can pull components from a private registry. This secret needs to
+be in the same namespace as the WasmCloudHostConfig CRD and must be a
+`kubernetes.io/dockerconfigjson` type secret. See the [Kubernetes
+documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials)
+for more information on how to provision that secret.
+
+Once it is created, you can reference it in the WasmCloudHostConfig CRD by
+setting the `registryCredentialsSecret` field to the name of the secret.
 
 ## Deploying the operator
 

--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -10,34 +10,54 @@ use std::collections::HashMap;
     kind = "WasmCloudHostConfig",
     group = "k8s.wasmcloud.dev",
     version = "v1alpha1",
-    shortname = "chc",
+    shortname = "whc",
     namespaced,
     status = "WasmCloudHostConfigStatus",
     printcolumn = r#"{"name":"App Count", "type":"integer", "jsonPath":".status.app_count"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct WasmCloudHostConfigSpec {
+    /// The number of replicas to use for the wasmCloud host Deployment.
     #[serde(default = "default_host_replicas")]
     pub host_replicas: u32,
+    /// A list of cluster issuers to use when provisioning hosts. See
+    /// https://wasmcloud.com/docs/deployment/security/zero-trust-invocations for more information.
     pub issuers: Vec<String>,
+    /// The lattice to use for these hosts.
     pub lattice: String,
+    /// An optional set of labels to apply to these hosts.
     pub host_labels: Option<HashMap<String, String>>,
+    /// The version of the wasmCloud host to deploy.
     pub version: String,
+    /// The name of a secret containing the primary cluster issuer key along with an optional set
+    /// of NATS credentials.
     pub secret_name: String,
+    /// Enable structured logging for host logs.
     pub enable_structured_logging: Option<bool>,
+    /// Name of a secret containing the registry credentials
     pub registry_credentials_secret: Option<String>,
+    /// Kubernetes resources to allocate for the host. See
+    /// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for valid
+    /// values to use here.
     pub resources: Option<WasmCloudHostConfigResources>,
+    /// The control topic prefix to use for the host.
     pub control_topic_prefix: Option<String>,
+    /// The leaf node domain to use for the NATS sidecar. Defaults to "leaf".
     #[serde(default = "default_leaf_node_domain")]
     pub leaf_node_domain: String,
+    /// Enable the config service for this host.
     #[serde(default)]
     pub config_service_enabled: bool,
+    /// The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
     #[serde(default = "default_nats_address")]
     pub nats_address: String,
+    /// The Jetstream domain to use for the NATS sidecar. Defaults to "default".
     #[serde(default = "default_jetstream_domain")]
     pub jetstream_domain: String,
+    /// The log level to use for the host. Defaults to "INFO".
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    /// Run hosts as a DaemonSet instead of a Deployment.
     #[serde(default)]
     pub daemonset: bool,
 }

--- a/sample.yaml
+++ b/sample.yaml
@@ -13,7 +13,7 @@ spec:
   hostLabels:
     test: value
   # Which wasmCloud version to use
-  version: 0.81.0
+  version: 0.82.0
   # The name of a secret in the same namespace that provides the required secrets.
   secretName: cluster-secrets
   logLevel: INFO


### PR DESCRIPTION
## Feature or Problem
Add documentation on how to use the `registryCredentialsSecret` to enable wasmCloud hosts to pull from a private registry.

Also add comments to each of the CRD fields outlining what each field does.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
