### PR TITLE
fix: use the correct OCI registry environment variables for newer hosts

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -470,7 +470,7 @@ async fn configure_hosts(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Res
 
         env_vars = vec![
             EnvVar {
-                name: "OCI_REGISTRY_USER".to_string(),
+                name: "WASMCLOUD_OCI_REGISTRY_USER".to_string(),
                 value: Some(
                     docker_config
                         .auths
@@ -483,7 +483,7 @@ async fn configure_hosts(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Res
                 ..Default::default()
             },
             EnvVar {
-                name: "OCI_REGISTRY_PASSWORD".to_string(),
+                name: "WASMCLOUD_OCI_REGISTRY_PASSWORD".to_string(),
                 value: Some(
                     docker_config
                         .auths
@@ -497,7 +497,7 @@ async fn configure_hosts(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Res
                 ..Default::default()
             },
             EnvVar {
-                name: "OCI_REGISTRY".to_string(),
+                name: "WASMCLOUD_OCI_REGISTRY".to_string(),
                 value: Some(docker_config.auths.keys().next().unwrap().clone()),
                 ..Default::default()
             },


### PR DESCRIPTION
## Feature or Problem
In wasmCloud 0.81.0 we deprecated the old `OCI_REGISTRY` variables in favor of prefixing them with `WASMCLOUD`. 0.82.0 fully removed those variables, so this updates the controller to use the new variables with an eye towards wasmCloud 1.0 compatibility.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
This removes support for hosts < 0.81.0 using custom registries, which should be fine.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
