### PR TITLE
fix: Address GHSA-g98v-hv3f-hcfr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,17 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,15 +1279,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1532,7 +1512,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2073,7 +2053,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4306,7 +4286,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-nats",
- "atty",
  "axum",
  "axum-server",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async-nats = {workspace = true}
 axum = {workspace = true}
 axum-server = {workspace = true}
 anyhow = {workspace = true}
-atty = {workspace = true}
 ctrlc = {workspace = true}
 futures = {workspace = true}
 handlebars = {workspace = true}
@@ -57,7 +56,6 @@ async-nats = "0.33"
 axum = { version = "0.6", features = ["headers"] }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
 anyhow = "1"
-atty = "0.2"
 ctrlc = "3"
 futures = "0.3"
 handlebars = "5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use opentelemetry::sdk::{
     trace::{self, RandomIdGenerator, Sampler},
     Resource as OTELResource,
 };
+use std::io::IsTerminal;
 use std::net::SocketAddr;
 use std::time::Duration;
 use tracing::{error, info};
@@ -87,7 +88,7 @@ fn configure_tracing(enabled: bool) -> anyhow::Result<()> {
     let env_filter_layer = tracing_subscriber::EnvFilter::from_default_env();
     let log_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_ansi(atty::is(atty::Stream::Stderr));
+        .with_ansi(std::io::stderr().is_terminal());
 
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 


### PR DESCRIPTION
## Feature or Problem

The use of `atty` is no longer necessary, or desirable, so let's make use of the [standard library functionality introduced in 1.70](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#isterminal) instead.

## Related Issues

https://github.com/wasmCloud/wasmcloud-operator/security/dependabot/1

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
