### PR TITLE
chore: Add dependency-review workflow for pull requests

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,9 @@
+# For more details on the available options, see:
+# https://github.com/actions/dependency-review-action?tab=readme-ov-file#configuration-options
+fail-on-severity: critical
+
+comment-summary-in-pr: always
+
+show-openssf-scorecard: true
+
+warn-on-openssf-scorecard-level: 3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: 'Dependency Review'
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v4
+    - name: Dependency Review
+      uses: actions/dependency-review-action@v4
+      with:
+        config-file: './.github/dependency-review-config.yml'


### PR DESCRIPTION
## Feature or Problem

GitHub recently announced the addition of [OpenSSF Scorecard support in the `dependency-review` GitHub Action](https://github.blog/changelog/2024-03-20-openssf-scorecard-info-is-now-available-in-the-dependency-review-action/), which brought this action to my attention.

Having looked at it, this looks like it could be a useful addition for the PR pipeline in order to help maintain awareness of the state of dependencies that are being introduced/changed.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
