### PR TITLE
feat(*): Bumps to 0.2 for wasmcloud 1.0 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-operator"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-operator"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -105,13 +105,8 @@ helm upgrade --install -f values.yaml nats-cluster nats/nats
 
 ### Running Wadm
 
-You can deploy Wadm to your Kubernetes cluster with the Wadm Helm chart. First, clone the Wadm repo from GitHub:
-
-```shell
-git clone https://github.com/wasmCloud/wadm.git
-```
-
-In the cloned repo, find the chart at `wadm/charts/wadm`. For a minimal deployment, all you need in your `values.yaml` file is:
+You can run Wadm in your Kubernetes cluster using our Helm chart. For a minimal deployment using the
+NATS server deployed above, all you need in your `values.yaml` file is:
 
 ```yaml
 wadm:
@@ -119,8 +114,11 @@ wadm:
     nats:
       server: "nats-cluster.default.svc.cluster.local:4222"
 ```
+
+You can deploy Wadm using your values file and Helm:
+
 ```sh
-helm install wadm -f values.yaml ./
+helm install wadm -f values.yaml --version 0.2.0 oci://ghcr.io/wasmcloud/charts/wadm
 ```
 
 ### Start the operator

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: wasmcloud-operator
       containers:
-        - image: ghcr.io/wasmcloud/wasmcloud-operator:latest
+        - image: ghcr.io/wasmcloud/wasmcloud-operator:0.2.0
           imagePullPolicy: Always
           name: wasmcloud-operator
           ports:

--- a/sample.yaml
+++ b/sample.yaml
@@ -13,7 +13,7 @@ spec:
   hostLabels:
     test: value
   # Which wasmCloud version to use
-  version: 1.0.0-rc.2
+  version: "1.0.0"
   # The name of a secret in the same namespace that provides the required secrets.
   secretName: cluster-secrets
   logLevel: INFO


### PR DESCRIPTION
This bumps both the version of the operator and the default host version in the example to 1.0. Also updates the README to use the released wadm chart