### PR TITLE
Add conditions to Endpoints part of the EndpointSlices reflecting wadm application Service entries

### DIFF
--- a/src/services.rs
+++ b/src/services.rs
@@ -15,7 +15,7 @@ use async_nats::{
 use cloudevents::{AttributesReader, Event as CloudEvent};
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::{Pod, Service, ServicePort, ServiceSpec};
-use k8s_openapi::api::discovery::v1::{Endpoint, EndpointPort, EndpointSlice};
+use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions, EndpointPort, EndpointSlice};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::{
     api::{Api, DeleteParams, ListParams, Patch, PatchParams},
@@ -522,6 +522,11 @@ pub async fn create_or_update_service(
                         .filter_map(|ip| {
                             ip.ip.as_ref().map(|i| Endpoint {
                                 addresses: vec![i.clone()],
+                                conditions: Some(EndpointConditions {
+                                    ready: Some(true),
+                                    serving: Some(true),
+                                    terminating: None,
+                                }),
                                 hostname: None,
                                 target_ref: None,
                                 ..Default::default()


### PR DESCRIPTION
## Feature or Problem

While working on something somewhat related, I noticed that third-party software that was trying to connect to the Services we create for wasmCloud applications could not do so.

After some spelunking, it turned out that the software in question was looking for the `Ready` condition of the `Endpoints` section of a given `EndpointSlice`, which was previously missing. 

This fixes that.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
