### PR TITLE
fix: allow nats address to include a port

### DIFF
--- a/hack/run-kind-cluster.sh
+++ b/hack/run-kind-cluster.sh
@@ -18,7 +18,7 @@ fi
 # https://github.com/kubernetes-sigs/kind/issues/2875
 # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-cat <<EOF | kind create cluster --image kindest/node:v1.29.2 --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.29.4 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:

--- a/sample.yaml
+++ b/sample.yaml
@@ -17,7 +17,7 @@ spec:
   # The name of a secret in the same namespace that provides the required secrets.
   secretName: cluster-secrets
   logLevel: INFO
-  natsAddress: nats://nats-cluster.default.svc.cluster.local
+  natsAddress: nats://nats-cluster.default.svc.cluster.local:7422
   ################################################
   # Additional options that can be set for hosts:
   ################################################
@@ -27,9 +27,9 @@ spec:
   #   - "kind-registry:5000"
   # Policy service configuration
   # policyService:
-  #   topic: "wasmcloud.policy"
-  #   #changesTopic: "bar"
-  #   timeoutMs: 10000
+  #  topic: "wasmcloud.policy"
+  #  changesTopic: "bar"
+  #  timeoutMs: 10000
   # Additional options to control how the underlying wasmCloud hosts are scheduled in Kubernetes.
   # This includes setting resource requirements for the nats and wasmCloud host
   # containers along with any additional pot template settings.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -835,7 +835,7 @@ jetstream {
 leafnodes {
   remotes: [
     {
-      url: "{{cluster_url}}:7422"
+      url: "{{cluster_url}}"
       {{#if use_credentials}}
       credentials: "/nats/nats.creds"
       {{/if}}


### PR DESCRIPTION
## Feature or Problem
This fix omits the preset NATS leaf node port `7422` from being automatically set if the `natsAddress` field is set in the CRD. This allows you to specify the port if it is not using the default at the cost of making it required.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
Tested locally with kind connected to a NATS cluster serving leaf node connections on a different port than the default
