### PR TITLE
feat: Add option to customize NATS leaf node image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-operator-types"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "k8s-openapi",
  "kube",

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-operator-types"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]

--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -33,6 +33,10 @@ pub struct WasmCloudHostConfigSpec {
     /// If not provided, the default image for the version will be used.
     /// Also if provided, the version field will be ignored.
     pub image: Option<String>,
+    /// The image to use for the NATS leaf that is deployed alongside the wasmCloud host.
+    /// If not provided, the default upstream image will be used.
+    /// If provided, it should be fully qualified by including the image tag.
+    pub nats_leaf_image: Option<String>,
     /// The name of a secret containing the primary cluster issuer key along with an optional set
     /// of NATS credentials.
     pub secret_name: String,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -410,10 +410,15 @@ fn pod_template(config: &WasmCloudHostConfig, _ctx: Arc<Context>) -> PodTemplate
         None => format!("ghcr.io/wasmcloud/wasmcloud:{}", config.spec.version),
     };
 
+    let leaf_image = match &config.spec.nats_leaf_image {
+        Some(img) => img.clone(),
+        None => "nats:2.10-alpine".to_string(),
+    };
+
     let containers = vec![
         Container {
             name: "nats-leaf".to_string(),
-            image: Some("nats:2.10-alpine".to_string()),
+            image: Some(leaf_image),
             args: Some(vec![
                 "-js".to_string(),
                 "--config".to_string(),


### PR DESCRIPTION
## Feature or Problem

We already have the option to override the wasmCloud host image, let's add one for the NATS leaf that gets deployed alongside the wasmCloud host.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
