### PR TITLE
feat: Certificate Authorities to wasmcloud host

### DIFF
--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -78,6 +78,8 @@ pub struct WasmCloudHostConfigSpec {
     pub scheduling_options: Option<KubernetesSchedulingOptions>,
     /// Observability options for configuring the OpenTelemetry integration
     pub observability: Option<ObservabilityConfiguration>,
+    /// Certificates: Authorities, client certificates
+    pub certificates: Option<WasmCloudHostCertificates>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -185,6 +187,36 @@ fn default_nats_port() -> u16 {
 
 fn default_nats_leafnode_port() -> u16 {
     7422
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct ConfigMapSource {
+    /// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    pub name: String,
+
+    /// Specify whether the ConfigMap must be defined
+    pub optional: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct SecretSource {
+    /// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    pub name: String,
+
+    /// Specify whether the ConfigMap must be defined
+    pub optional: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateSource {
+    pub config_map_ref: Option<ConfigMapSource>,
+    pub secret_ref: Option<SecretSource>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct WasmCloudHostCertificates {
+    pub authorities: Option<Vec<CertificateSource>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -1,4 +1,4 @@
-use k8s_openapi::api::core::v1::{PodSpec, ResourceRequirements};
+use k8s_openapi::api::core::v1::{PodSpec, ResourceRequirements, Volume};
 use kube::CustomResource;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -190,33 +190,8 @@ fn default_nats_leafnode_port() -> u16 {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-pub struct ConfigMapSource {
-    /// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-    pub name: String,
-
-    /// Specify whether the ConfigMap must be defined
-    pub optional: Option<bool>,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-pub struct SecretSource {
-    /// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-    pub name: String,
-
-    /// Specify whether the ConfigMap must be defined
-    pub optional: Option<bool>,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct CertificateSource {
-    pub config_map_ref: Option<ConfigMapSource>,
-    pub secret_ref: Option<SecretSource>,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct WasmCloudHostCertificates {
-    pub authorities: Option<Vec<CertificateSource>>,
+    pub authorities: Option<Vec<Volume>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -424,8 +424,8 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
                 let volume_name = format!("cert-authority-{}", i);
                 let volume_path = format!("/wasmcloud/certificates/authorities/{}", volume_name);
                 match discover_configmap_certificates(
-                    config.namespace().unwrap_or_default(),
-                    configmap.name.clone(),
+                    config.namespace().unwrap_or_default().as_str(),
+                    configmap.name.clone().as_str(),
                     &ctx,
                 )
                 .await
@@ -554,15 +554,15 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
 }
 
 async fn discover_configmap_certificates(
-    namespace: String,
-    name: String,
+    namespace: &str,
+    name: &str,
     ctx: &Context,
 ) -> Result<Vec<String>> {
     let kube_client = ctx.client.clone();
     let api = Api::<ConfigMap>::namespaced(kube_client, &namespace);
     let mut certs = Vec::new();
 
-    let raw_config_map = api.get(name.as_str()).await?;
+    let raw_config_map = api.get(name).await?;
 
     if let Some(raw_data) = raw_config_map.data {
         for (key, _) in raw_data {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -421,11 +421,11 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
         for (i, authority) in authorities.iter().enumerate() {
             // configmaps
             if let Some(configmap) = &authority.config_map_ref {
-                let volume_name = format!("cert-authority-{}", i);
-                let volume_path = format!("/wasmcloud/certificates/authorities/{}", volume_name);
+                let volume_name = format!("cert-authority-{i}");
+                let volume_path = format!("/wasmcloud/certificates/authorities/{volume_name}");
                 match discover_configmap_certificates(
                     config.namespace().unwrap_or_default().as_str(),
-                    configmap.name.clone().as_str(),
+                    configmap.name.as_str(),
                     &ctx,
                 )
                 .await

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -424,7 +424,7 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
                 let volume_name = format!("cert-authority-{}", i);
                 let volume_path = format!("/wasmcloud/certificates/authorities/{}", volume_name);
                 match discover_configmap_certificates(
-                    config.namespace().unwrap(),
+                    config.namespace().unwrap_or_default(),
                     configmap.name.clone(),
                     &ctx,
                 )

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -424,6 +424,13 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
             let volume_path = format!("/wasmcloud/certificates/{volume_name}");
             let mut items: Vec<String> = vec![];
 
+            // The Volume interface is quite broad. Permit only known types.
+            if authority.secret.is_none() && authority.config_map.is_none() {
+                return Err(Error::CertificateError(format!(
+                    "'{authority_name}' has to be a Configmap or Secret"
+                )));
+            }
+
             // secrets
             if let Some(secret_ref) = &authority.secret {
                 let secret_name = match &secret_ref.secret_name {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -436,8 +436,8 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
                 };
 
                 items = discover_secret_certificates(
-                    config.namespace().unwrap_or_default().as_str(),
-                    secret_name.as_str(),
+                    &config.namespace().unwrap_or_default(),
+                    secret_name,
                     &ctx,
                 )
                 .await?;
@@ -467,8 +467,8 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
                     }
                 };
                 items = discover_configmap_certificates(
-                    config.namespace().unwrap_or_default().as_str(),
-                    configmap_name.as_str(),
+                    &config.namespace().unwrap_or_default(),
+                    configmap_name,
                     &ctx,
                 )
                 .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ pub enum Error {
     #[error("Error retrieving secrets: {0}")]
     SecretError(String),
 
+    #[error("Certificate error: {0}")]
+    CertificateError(String),
+
     #[error("Error rendering template: {0}")]
     RenderError(#[from] RenderError),
 }


### PR DESCRIPTION
# what

Fixes https://github.com/wasmCloud/wasmcloud-operator/issues/69

Requires https://github.com/wasmCloud/wasmCloud/pull/2468

Allow passing one or more certificate authorities into wasmcloud via configmaps & secrets.

Example authorities:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: org-authorities
data:
  dontmountme: |
    -----BEGIN CERTIFICATE-----
    Custom CA certificate bundle.
    -----END CERTIFICATE-----
  root.crt: |
    -----BEGIN CERTIFICATE-----
    Custom CA certificate bundle.
    -----END CERTIFICATE-----

---
apiVersion: v1
kind: Secret
metadata:
  name: email-authorities
stringData:
  email.crt: |
    -----BEGIN CERTIFICATE-----
    Custom CA certificate bundle.
    -----END CERTIFICATE-----
  notifications.crt: |
    -----BEGIN CERTIFICATE-----
    Custom CA certificate bundle.
    -----END CERTIFICATE-----

```

# how

We pass configmaps as part of the wasmcloud host definition:

```
apiVersion: k8s.wasmcloud.dev/v1alpha1
kind: WasmCloudHostConfig
metadata:
  name: wasmcloud-host
spec:
  lattice: default
  version: "1.0.4"
  natsAddress: nats://nats-cluster.default.svc.cluster.local
  certificates:
    authorities:
      - name: org-wide-authorities
         configmap:
           name: org-authorities
      - name: partner-authorities
         secret:
           secretName: email-authorities
```

The `authorities` list follows the Volume convention as defined in https://pkg.go.dev/k8s.io/api/core/v1#VolumeSource

The operator will mount the `org-authorities` configmap into the wasmcloud host container under `/wasmcloud/certificates/ca-org-wide-authorities`. Notice we prefix the authority name with `ca-`.
The operator then scans the configmap for items that end in `.crt` ( certificate ) and append them to the arguments passed to wasmcloud host. Ex: if the configmap has the keys `dontmountme` and `root.crt`, only the `root.crt` will be passed into wasmcloud as `--tls-ca-path /wasmcloud/certificates/ca-org-wide-authorities/root.crt`.

The same applies to Secrets.

We also raise a reconciliation error in case the desired object is not defined or not found.
