### PR TITLE
chore: Bump wasmcloud-operator version references in deployment artifacts

### DIFF
--- a/charts/wasmcloud-operator/Chart.yaml
+++ b/charts/wasmcloud-operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.3"
+appVersion: "0.3.2"

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: wasmcloud-operator
       containers:
-        - image: ghcr.io/wasmcloud/wasmcloud-operator:0.2.3
+        - image: ghcr.io/wasmcloud/wasmcloud-operator:0.3.2
           imagePullPolicy: Always
           name: wasmcloud-operator
           ports:


### PR DESCRIPTION
## Feature or Problem

In preparation for the [release of `0.3.2`](https://github.com/wasmCloud/wasmcloud-operator/releases/tag/v0.3.2), let's update both of the deployment artifacts to reference the latest version.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
