### PR TITLE
fix(examples): add daemonscaler to httpserver

### DIFF
--- a/examples/quickstart/hello-world-application.yaml
+++ b/examples/quickstart/hello-world-application.yaml
@@ -43,3 +43,6 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
+        - type: daemonscaler
+          properties:
+            replicas: 1


### PR DESCRIPTION
This will allow the k8s operator to automatically create services. This shouldn't be required in the future when the operator supports the spreadscaler for httpserver providers as well.
