### PR TITLE
feat: Configure max component memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-operator"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-operator-types"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "k8s-openapi",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-operator"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [[bin]]
@@ -77,7 +77,7 @@ opentelemetry_sdk = { version = "0.21", features = [
   "metrics",
   "trace",
   "rt-tokio",
-]}
+] }
 opentelemetry-otlp = { version = "0.14", features = ["tokio"] }
 rcgen = "0.11"
 schemars = "0.8"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasmcloud-operator-types"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [dependencies]
-k8s-openapi = {workspace = true}
-kube = {workspace = true, features = ["derive"]}
-schemars = {workspace = true}
-serde = {workspace = true}
-serde_json = {workspace = true}
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["derive"] }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -82,6 +82,8 @@ pub struct WasmCloudHostConfigSpec {
     pub certificates: Option<WasmCloudHostCertificates>,
     /// wasmCloud secrets topic prefix, must not be empty if set.
     pub secrets_topic_prefix: Option<String>,
+    /// Maximum memory in bytes that components can use.
+    pub max_linear_memory_bytes: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/examples/full-config/wasmcloud-annotated.yaml
+++ b/examples/full-config/wasmcloud-annotated.yaml
@@ -71,6 +71,8 @@ spec:
   # Optional: Subject prefix that will be used by the host to query for wasmCloud Secrets.
   # See https://wasmcloud.com/docs/concepts/secrets for more context
   secretsTopicPrefix: "wasmcloud.secrets"
+  # Optional: The maximum amount of memory bytes that a component can allocate.
+  maxLinearMemoryBytes: 20000000
   # Optional: Additional options to control how the underlying wasmCloud hosts are scheduled in Kubernetes.
   # This includes setting resource requirements for the nats and wasmCloud host
   # containers along with any additional pot template settings.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -381,6 +381,14 @@ async fn pod_template(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Result
         })
     }
 
+    if let Some(max_linear_memory_bytes) = &config.spec.max_linear_memory_bytes {
+        wasmcloud_env.push(EnvVar {
+            name: "WASMCLOUD_MAX_LINEAR_MEMORY".to_string(),
+            value: Some(max_linear_memory_bytes.to_string()),
+            ..Default::default()
+        })
+    }
+
     let mut wasmcloud_args = configure_observability(&config.spec);
 
     let mut nats_resources: Option<k8s_openapi::api::core::v1::ResourceRequirements> = None;


### PR DESCRIPTION
⚠️  Needs wasmcloud 1.2 https://github.com/wasmCloud/wasmCloud/releases/tag/v1.2.0-rc.1

Configures the maximum amount of bytes that a component can allocate.
https://github.com/wasmCloud/wasmCloud/pull/2713