### PR TITLE
feat: Add rudimentary version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-operator"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-operator"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,13 @@ use wasmcloud_operator_types::v1alpha1::WasmCloudHostConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.iter().any(|arg| arg == "-V" || arg == "--version") {
+        let version = version();
+        println!("{} {version}", env!("CARGO_BIN_NAME"));
+        std::process::exit(0);
+    }
+
     let tracing_enabled = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok();
     configure_tracing(tracing_enabled).map_err(|e| {
         error!("Failed to configure tracing: {}", e);
@@ -191,4 +198,8 @@ async fn install_crd(client: &Client) -> anyhow::Result<()> {
     };
 
     Ok(())
+}
+
+fn version() -> &'static str {
+    option_env!("CARGO_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
 }


### PR DESCRIPTION
## Feature or Problem

This adds a rudimentary version flag for checking the version of wasmcloud-operator.

The chosen values for representing the flag align with `clap` defaults ([`version`](https://docs.rs/clap/latest/clap/struct.Command.html#method.version), [`long_version`](https://docs.rs/clap/latest/clap/struct.Command.html#method.long_version)) in case we wanted to use `clap` in the future, for now it felt unnecessary for adding support for this flag alone.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
