### PR TITLE
Force apply changes on patches for unresolvable conflicts

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -874,7 +874,7 @@ async fn configure_hosts(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Res
         let api = Api::<DaemonSet>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
         api.patch(
             &config.name_any(),
-            &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+            &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
             &Patch::Apply(ds),
         )
         .await?;
@@ -900,7 +900,7 @@ async fn configure_hosts(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Res
         let api = Api::<Deployment>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
         api.patch(
             &config.name_any(),
-            &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+            &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
             &Patch::Apply(deployment),
         )
         .await?;
@@ -942,7 +942,7 @@ async fn configure_service(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> R
     let api = Api::<Service>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
     api.patch(
         &config.name_any(),
-        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
         &Patch::Apply(svc),
     )
     .await?;
@@ -963,7 +963,7 @@ async fn configure_auth(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Resu
     let api = Api::<ServiceAccount>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
     api.patch(
         &config.name_any(),
-        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
         &Patch::Apply(svc_account),
     )
     .await?;
@@ -993,7 +993,7 @@ async fn configure_auth(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Resu
     let api = Api::<Role>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
     api.patch(
         &config.name_any(),
-        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
         &Patch::Apply(role),
     )
     .await?;
@@ -1020,7 +1020,7 @@ async fn configure_auth(config: &WasmCloudHostConfig, ctx: Arc<Context>) -> Resu
     let api = Api::<RoleBinding>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
     api.patch(
         &config.name_any(),
-        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
         &Patch::Apply(role_binding),
     )
     .await?;
@@ -1066,7 +1066,7 @@ leafnodes {
     let api = Api::<ConfigMap>::namespaced(ctx.client.clone(), &config.namespace().unwrap());
     api.patch(
         &config.name_any(),
-        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
         &Patch::Apply(cm),
     )
     .await?;

--- a/src/services.rs
+++ b/src/services.rs
@@ -438,7 +438,7 @@ pub async fn create_or_update_service(
         let svc = api
             .patch(
                 params.name.as_str(),
-                &PatchParams::apply(SERVICE_FINALIZER),
+                &PatchParams::apply(SERVICE_FINALIZER).force(),
                 &Patch::Apply(svc),
             )
             .await
@@ -536,7 +536,7 @@ pub async fn create_or_update_service(
                 endpoints
                     .patch(
                         params.name.as_str(),
-                        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER),
+                        &PatchParams::apply(CLUSTER_CONFIG_FINALIZER).force(),
                         &Patch::Apply(endpoint_slice),
                     )
                     .await


### PR DESCRIPTION
## Feature or Problem

When, for instance, updating the replica count of the downstream deployment of a `WasmCloudHostConfig` to not match the `host_replicas`, the operator will fail to reconcile the deployment back to the desired replicas due to a field manager conflict. As the controller owns the resource, it should be able to always apply patches to it and recover ownership of the fields that were modified.

## Related Issues

See #140 

## Release Information

Next.

## Consumer Impact

Should result in less inconsistencies when people accidentally modify resources that are technically managed by the operator.

## Testing

### Unit Test(s)

None.

### Acceptance or Integration

None.

### Manual Verification

Deployed a new version and performed various manual changes to the setup to see if the operator would reconcile them.
