### PR TITLE
Add support to provide useful host information in resource status

### DIFF
--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -238,8 +238,16 @@ pub struct WasmCloudHostConfigResources {
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct WasmCloudHostConfigStatus {
+    pub hosts: WasmCloudHostStatus,
     pub apps: Vec<AppStatus>,
     pub app_count: u32,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+pub struct WasmCloudHostStatus {
+    pub available_replicas: Option<i32>,
+    pub updated_replicas: Option<i32>,
+    pub replicas: Option<i32>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -72,6 +72,13 @@ rules:
       - patch
       - update
   - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+      - daemonsets/status
+    verbs:
+      - get
+  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings


### PR DESCRIPTION
## Feature or Problem

While the host CRs provide information about the deployed applications, it does not provide any information about the hosts that it is meant to deploy. This PR adds information on the number of replicas it has deployed, whether they are up-to-date, and how many replicas exist overall.

## Related Issues

Relates-to: #22

## Release Information

Next.

## Consumer Impact

None. They can however use the status to better understand how the hosts behave.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)

None.

### Acceptance or Integration

None.

### Manual Verification

Deployed on a multi-node Kubernetes cluster and tested various configurations and updates both in Daemonset mode and in normal mode.
