### PR TITLE
feat: add natsLeaf configuration with TLS and extra volumes support

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:1.77-bookworm as builder
+FROM rust:1.85-bookworm as builder
 
 WORKDIR /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ spec:
   image: registry.example.com/wasmcloud:1.0.2
 ```
 
-For the NATS leaf, use the `natsImageLeaf` field:
+For the NATS leaf sidecar, use the `natsLeaf` configuration block:
 
 ```yaml
 apiVersion: k8s.wasmcloud.dev/v1alpha1
@@ -75,7 +75,47 @@ metadata:
   name: my-wasmcloud-cluster
 spec:
   # other config options omitted
-  natsLeafImage: registry.example.com/nats:2.10.16
+  natsLeaf:
+    image: registry.example.com/nats:2.10.16
+    address: nats://nats.default.svc.cluster.local
+    credentialsSecret: wasmcloud-nats-creds
+    jetstreamDomain: default
+```
+
+#### Configuring TLS for the NATS leaf connection
+
+If your NATS server uses TLS, you can configure the leaf node to verify the server certificate by providing a CA certificate. Use `extraVolumes` and `extraVolumeMounts` to mount the certificate into the container:
+
+```yaml
+apiVersion: k8s.wasmcloud.dev/v1alpha1
+kind: WasmCloudHostConfig
+metadata:
+  name: my-wasmcloud-cluster
+spec:
+  # other config options omitted
+  natsLeaf:
+    address: nats://nats.example.com
+    credentialsSecret: wasmcloud-nats-creds
+    jetstreamDomain: default
+    tls:
+      ca: /nats/ca/ca-certificates.crt
+    extraVolumes:
+      - name: nats-ca
+        configMap:
+          name: my-ca-bundle
+    extraVolumeMounts:
+      - name: nats-ca
+        mountPath: /nats/ca
+        readOnly: true
+```
+
+For mTLS (mutual TLS), you can also provide client certificate and key paths:
+
+```yaml
+    tls:
+      ca: /nats/ca/ca-certificates.crt
+      cert: /nats/certs/tls.crt
+      key: /nats/certs/tls.key
 ```
 
 ### Image Pull Secrets

--- a/charts/wadm-operator/templates/deployment.yaml
+++ b/charts/wadm-operator/templates/deployment.yaml
@@ -41,12 +41,23 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/wadm-operator/values.yaml
+++ b/charts/wadm-operator/values.yaml
@@ -61,3 +61,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Extra environment variables to add to the operator container
+extraEnv: []
+  # - name: SSL_CERT_FILE
+  #   value: /custom-certs/ca-certificates.crt
+
+# Extra volumes to add to the pod
+extraVolumes: []
+  # - name: custom-certs
+  #   configMap:
+  #     name: combined-ca-bundle
+
+# Extra volume mounts to add to the operator container
+extraVolumeMounts: []
+  # - name: custom-certs
+  #   mountPath: /custom-certs
+  #   readOnly: true

--- a/crates/types/src/v1alpha1/wasmcloud_host_config.rs
+++ b/crates/types/src/v1alpha1/wasmcloud_host_config.rs
@@ -1,4 +1,4 @@
-use k8s_openapi::api::core::v1::{Container, PodSpec, ResourceRequirements, Volume};
+use k8s_openapi::api::core::v1::{Container, PodSpec, ResourceRequirements, Volume, VolumeMount};
 use kube::CustomResource;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -34,11 +34,13 @@ pub struct WasmCloudHostConfigSpec {
     /// If not provided, the default image for the version will be used.
     /// Also if provided, the version field will be ignored.
     pub image: Option<String>,
+    /// DEPRECATED: Use `natsLeaf.image` instead.
     /// The image to use for the NATS leaf that is deployed alongside the wasmCloud host.
-    /// If not provided, the default upstream image will be used.
-    /// If provided, it should be fully qualified by including the image tag.
+    #[deprecated(note = "Use natsLeaf.image instead")]
     pub nats_leaf_image: Option<String>,
+    /// DEPRECATED: Use `natsLeaf.credentialsSecret` instead.
     /// Optional. The name of a secret containing a set of NATS credentials under 'nats.creds' key.
+    #[deprecated(note = "Use natsLeaf.credentialsSecret instead")]
     pub secret_name: Option<String>,
     /// Enable structured logging for host logs.
     pub enable_structured_logging: Option<bool>,
@@ -46,22 +48,32 @@ pub struct WasmCloudHostConfigSpec {
     pub registry_credentials_secret: Option<String>,
     /// The control topic prefix to use for the host.
     pub control_topic_prefix: Option<String>,
+    /// DEPRECATED: Use `natsLeaf.domain` instead.
     /// The leaf node domain to use for the NATS sidecar. Defaults to "leaf".
+    #[deprecated(note = "Use natsLeaf.domain instead")]
     #[serde(default = "default_leaf_node_domain")]
     pub leaf_node_domain: String,
     /// Enable the config service for this host.
     #[serde(default)]
     pub config_service_enabled: bool,
+    /// DEPRECATED: Use `natsLeaf.address` instead.
     /// The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
+    #[deprecated(note = "Use natsLeaf.address instead")]
     #[serde(default = "default_nats_address")]
     pub nats_address: String,
+    /// DEPRECATED: Use `natsLeaf.clientPort` instead.
     /// The port of the NATS server to connect to. Defaults to 4222.
+    #[deprecated(note = "Use natsLeaf.clientPort instead")]
     #[serde(default = "default_nats_port")]
     pub nats_client_port: u16,
+    /// DEPRECATED: Use `natsLeaf.leafnodePort` instead.
     /// The port of the NATS server to connect to for leaf node connections. Defaults to 7422.
+    #[deprecated(note = "Use natsLeaf.leafnodePort instead")]
     #[serde(default = "default_nats_leafnode_port")]
     pub nats_leafnode_port: u16,
+    /// DEPRECATED: Use `natsLeaf.jetstreamDomain` instead.
     /// The Jetstream domain to use for the NATS sidecar. Defaults to "default".
+    #[deprecated(note = "Use natsLeaf.jetstreamDomain instead")]
     #[serde(default = "default_jetstream_domain")]
     pub jetstream_domain: String,
     /// Allow the host to deploy using the latest tag on OCI components or providers
@@ -84,6 +96,117 @@ pub struct WasmCloudHostConfigSpec {
     pub secrets_topic_prefix: Option<String>,
     /// Maximum memory in bytes that components can use.
     pub max_linear_memory_bytes: Option<u32>,
+    /// Configuration for the NATS leaf node sidecar.
+    pub nats_leaf: Option<NatsLeafConfig>,
+}
+
+#[allow(deprecated)]
+impl WasmCloudHostConfigSpec {
+    pub fn effective_nats_leaf_image(&self) -> Option<String> {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.image.clone())
+            .or_else(|| self.nats_leaf_image.clone())
+    }
+
+    pub fn effective_credentials_secret(&self) -> Option<String> {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.credentials_secret.clone())
+            .or_else(|| self.secret_name.clone())
+    }
+
+    pub fn effective_leaf_node_domain(&self) -> String {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.domain.clone())
+            .unwrap_or_else(|| self.leaf_node_domain.clone())
+    }
+
+    pub fn effective_nats_address(&self) -> String {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.address.clone())
+            .unwrap_or_else(|| self.nats_address.clone())
+    }
+
+    pub fn effective_nats_client_port(&self) -> u16 {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.client_port)
+            .unwrap_or(self.nats_client_port)
+    }
+
+    pub fn effective_nats_leafnode_port(&self) -> u16 {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.leafnode_port)
+            .unwrap_or(self.nats_leafnode_port)
+    }
+
+    pub fn effective_jetstream_domain(&self) -> String {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.jetstream_domain.clone())
+            .unwrap_or_else(|| self.jetstream_domain.clone())
+    }
+
+    pub fn nats_leaf_tls(&self) -> Option<&NatsLeafTlsConfig> {
+        self.nats_leaf.as_ref().and_then(|n| n.tls.as_ref())
+    }
+
+    pub fn nats_leaf_extra_volumes(&self) -> Vec<Volume> {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.extra_volumes.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn nats_leaf_extra_volume_mounts(&self) -> Vec<VolumeMount> {
+        self.nats_leaf
+            .as_ref()
+            .and_then(|n| n.extra_volume_mounts.clone())
+            .unwrap_or_default()
+    }
+}
+
+/// Configuration for the NATS leaf node sidecar container.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NatsLeafConfig {
+    /// The image to use for the NATS leaf container.
+    /// If not provided, the default upstream image will be used.
+    pub image: Option<String>,
+    /// The leaf node domain to use for the NATS sidecar.
+    pub domain: Option<String>,
+    /// The address of the NATS server to connect to.
+    pub address: Option<String>,
+    /// The port of the NATS server to connect to.
+    pub client_port: Option<u16>,
+    /// The port of the NATS server to connect to for leaf node connections.
+    pub leafnode_port: Option<u16>,
+    /// The Jetstream domain to use for the NATS sidecar.
+    pub jetstream_domain: Option<String>,
+    /// The name of a secret containing NATS credentials under 'nats.creds' key.
+    pub credentials_secret: Option<String>,
+    /// TLS configuration for the NATS leaf node connection.
+    pub tls: Option<NatsLeafTlsConfig>,
+    /// Extra volumes to add to the pod for the NATS leaf container.
+    pub extra_volumes: Option<Vec<Volume>>,
+    /// Extra volume mounts to add to the NATS leaf container.
+    pub extra_volume_mounts: Option<Vec<VolumeMount>>,
+}
+
+/// TLS configuration for the NATS leaf node connection.
+/// Paths should point to files mounted via `extraVolumes` and `extraVolumeMounts`.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct NatsLeafTlsConfig {
+    /// Path to the CA certificate file for verifying the server's certificate.
+    pub ca: Option<String>,
+    /// Path to the client certificate file for mTLS authentication.
+    pub cert: Option<String>,
+    /// Path to the client private key file for mTLS authentication.
+    pub key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -228,6 +351,12 @@ fn default_nats_leafnode_port() -> u16 {
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct WasmCloudHostCertificates {
     pub authorities: Option<Vec<Volume>>,
+}
+
+impl NatsLeafTlsConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.ca.is_some() || self.cert.is_some() || self.key.is_some()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/examples/full-config/wasmcloud-annotated.yaml
+++ b/examples/full-config/wasmcloud-annotated.yaml
@@ -17,11 +17,6 @@ spec:
   # Optional: The image to use for the wasmCloud host.
   # If provided, the 'version' field will be ignored.
   image: "registry/wasmcloud:tag"
-  # Optional: The image to use for the NATS leaf that is deployed alongside the wasmCloud host.
-  # If not provided, the default upstream image will be used.
-  natsLeafImage: "registry/nats:tag"
-  # Optional. The name of a secret containing a set of NATS credentials under 'nats.creds' key.
-  secretName: "wasmcloud-host-nats-secret"
   # Optional: Enable structured logging for host logs. Defaults to "false".
   enableStructuredLogging: true
   # Optional: The name of a secret containing the registry credentials.
@@ -29,15 +24,51 @@ spec:
   registryCredentialsSecret: "wasmcloud-pull-secret"
   # Optional: The control topic prefix to use for the host. Defaults to "wasmbus.ctl"
   controlTopicPrefix: "wasmbus.custom-ctl"
-  # Optional: The leaf node domain to use for the NATS sidecar. Defaults to "leaf".
-  leafNodeDomain: "custom-leaf"
   # Optional: Enable the config service for this host. Defaults to "false".
   # Makes wasmCloud host issue requests to a config service on startup.
   configServiceEnabled: true
   # Optional: The log level to use for the host. Defaults to "INFO".
   logLevel: INFO
-  # Optional: The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
-  natsAddress: nats://nats.default.svc.cluster.local
+  # Optional: Configuration for the NATS leaf node sidecar.
+  natsLeaf:
+    # Optional: The image to use for the NATS leaf container.
+    image: "registry/nats:tag"
+    # Optional: The leaf node domain to use for the NATS sidecar. Defaults to "leaf".
+    domain: "custom-leaf"
+    # Optional: The address of the NATS server to connect to. Defaults to "nats://nats.default.svc.cluster.local".
+    address: "nats://nats.default.svc.cluster.local"
+    # Optional: The port of the NATS server to connect to. Defaults to 4222.
+    clientPort: 4222
+    # Optional: The port of the NATS server to connect to for leaf node connections. Defaults to 7422.
+    leafnodePort: 7422
+    # Optional: The Jetstream domain to use for the NATS sidecar. Defaults to "default".
+    jetstreamDomain: "default"
+    # Optional: The name of a secret containing a set of NATS credentials under 'nats.creds' key.
+    credentialsSecret: "wasmcloud-host-nats-secret"
+    # Optional: TLS configuration for the NATS leaf node connection.
+    tls:
+      # Path to the CA certificate file for verifying the server's certificate.
+      ca: "/nats/ca/ca-certificates.crt"
+      # Path to the client certificate file for mTLS authentication.
+      cert: "/nats/certs/tls.crt"
+      # Path to the client private key file for mTLS authentication.
+      key: "/nats/certs/tls.key"
+    # Optional: Extra volumes to add to the pod for the NATS leaf container.
+    extraVolumes:
+      - name: nats-ca
+        configMap:
+          name: global-trust-bundle
+      - name: nats-certs
+        secret:
+          secretName: nats-client-tls
+    # Optional: Extra volume mounts to add to the NATS leaf container.
+    extraVolumeMounts:
+      - name: nats-ca
+        mountPath: "/nats/ca"
+        readOnly: true
+      - name: nats-certs
+        mountPath: "/nats/certs"
+        readOnly: true
   # Optional: Allow the host to deploy using the latest tag on OCI components or providers. Defaults to "false".
   allowLatest: true
   # Optional: Allow the host to pull artifacts from OCI registries insecurely.

--- a/examples/quickstart/wasmcloud-host.yaml
+++ b/examples/quickstart/wasmcloud-host.yaml
@@ -5,3 +5,18 @@ metadata:
 spec:
   lattice: default
   version: "1.0.4"
+  # Optional: Configure the NATS leaf sidecar with TLS support
+  # natsLeaf:
+  #   address: nats://nats.default.svc.cluster.local
+  #   credentialsSecret: "wasmcloud-nats-creds"
+  #   jetstreamDomain: "default"
+  #   tls:
+  #     ca: "/nats/ca/ca-certificates.crt"
+  #   extraVolumes:
+  #     - name: nats-ca
+  #       configMap:
+  #         name: my-ca-bundle
+  #   extraVolumeMounts:
+  #     - name: nats-ca
+  #       mountPath: "/nats/ca"
+  #       readOnly: true

--- a/src/resources/application.rs
+++ b/src/resources/application.rs
@@ -368,8 +368,8 @@ pub async fn list_all_applications(
         // Prevent listing applications within a given lattice more than once
         if !lattices.contains(&lattice_id) {
             let result = match list_apps(
-                &cfg.spec.nats_address,
-                &cfg.spec.nats_client_port,
+                &cfg.spec.effective_nats_address(),
+                &cfg.spec.effective_nats_client_port(),
                 secret,
                 lattice_id.clone(),
             )
@@ -429,8 +429,8 @@ pub async fn list_applications(
         // This is to check that we don't list a lattice more than once
         if !lattices.contains(&lattice_id) {
             let result = match list_apps(
-                &cfg.spec.nats_address,
-                &cfg.spec.nats_client_port,
+                &cfg.spec.effective_nats_address(),
+                &cfg.spec.effective_nats_client_port(),
                 secret,
                 lattice_id.clone(),
             )
@@ -732,11 +732,11 @@ async fn get_lattice_connection(
     let connection_data =
         cfgs.map(|cfg| (cfg, namespace.clone()))
             .filter_map(|(cfg, namespace)| {
-                let cluster_url = cfg.spec.nats_address;
-                let lattice_id = cfg.spec.lattice;
+                let cluster_url = cfg.spec.effective_nats_address();
+                let lattice_id = cfg.spec.lattice.clone();
                 let lattice_name = cfg.metadata.name?;
                 let nst: NameNamespace = NameNamespace::new(lattice_name, namespace);
-                let port = cfg.spec.nats_client_port;
+                let port = cfg.spec.effective_nats_client_port();
                 Some((cluster_url, nst, lattice_id, port))
             });
 


### PR DESCRIPTION
Adds a new consolidated natsLeaf configuration block that includes:
- All NATS-related settings (image, address, ports, domain, credentials)
- TLS configuration with ca, cert, and key path options
- Extra volumes and volume mounts for the NATS leaf container

The existing top-level NATS fields are deprecated but still functional for backwards compatibility. The new natsLeaf fields take precedence.

This allows users to:
1. Mount custom TLS certificates via extraVolumes/extraVolumeMounts
2. Configure NATS leaf TLS by specifying paths to the mounted certs
3. Consolidate all NATS leaf configuration in one place

## Feature or Problem

When connecting wasmCloud hosts to a NATS server that uses TLS with self-signed or private CA certificates, users previously had no way to configure the NATS leaf sidecar to trust the CA. This resulted in `certificate signed by unknown authority` errors when connecting to TLS-enabled NATS clusters.

Additionally, NATS-related configuration was scattered across multiple top-level fields (`natsLeafImage`, `secretName`, `leafNodeDomain`, `natsAddress`, `natsClientPort`, `natsLeafnodePort`, `jetstreamDomain`), making it harder to understand and configure.

## Related Issues

None

## Release Information

Next release

## Consumer Impact

**Low impact** - This is a backwards-compatible change. Existing configurations using the top-level NATS fields will continue to work. Users are encouraged to migrate to the new `natsLeaf` block for new deployments.

New `natsLeaf` fields take precedence over the deprecated top-level fields when both are specified.

## Testing

### Unit Test(s)

Existing unit tests pass. No new unit tests were added.

### Acceptance or Integration

No changes to acceptance or integration tests.

### Manual Verification

1. Built the operator locally with `cargo build`
2. Ran `cargo check` - completed successfully
3. Ran `cargo test` - all tests passed
4. Deployed to a local Kubernetes cluster with a TLS-enabled NATS server using a private CA
5. Verified the generated `nats.conf` ConfigMap includes the TLS block with correct paths
6. Verified the NATS leaf container successfully connects to the NATS server using TLS